### PR TITLE
Clarify since/until/since_id/max_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Geo | `near:city` | Geotagged in this place. Also supports Phrases, eg: "The Hag
 &nbsp; | `geocode:lat,long,radius` | E.g., to get tweets 10km around twitters hq, use `geocode:37.7764685,-122.4172004,10km` | [🔗](https://twitter.com/search?q=geocode%3A37.7764685%2C-122.4172004%2C10km&src=typed_query)
 &nbsp; | `place:96683cc9126741d1` | Search tweets by [Place Object](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/geo-objects.html#place) ID eg: USA Place ID is `96683cc9126741d1` | [🔗](https://twitter.com/search?q=place%3A96683cc9126741d1&src=typed_query)
 &nbsp; | | | 
-Time | `since:yyyy-mm-dd` | On or after a specified date | [🔗](https://twitter.com/search?q=since%3A2019-06-12%20until%3A2019-06-28%20%23nasamoontunes&src=typed_query)
-&nbsp; | `until:yyyy-mm-dd` | On or before a specified date. Combine with the "since" operator for dates between. | [🔗](https://twitter.com/search?q=since%3A2019-06-12%20until%3A2019-06-28%20%23nasamoontunes&src=typed_query)
-&nbsp; | `max_id:tweet_id` | Snowflake ID based for exact time search (see [Note](#snowflake-ids) below) | [🔗](https://twitter.com/search?q=since_id%3A1138872932887924737%20max_id%3A1144730280353247233%20%23nasamoontunes&src=typed_query)
-&nbsp; | `since_id:tweet_id` | Works together with `max_id` and another operator | [🔗](https://twitter.com/search?q=since_id%3A1138872932887924737%20max_id%3A1144730280353247233%20%23nasamoontunes&src=typed_query)
+Time | `since:yyyy-mm-dd` | On or after (inclusive) a specified date  | [🔗](https://twitter.com/search?q=since%3A2019-06-12%20until%3A2019-06-28%20%23nasamoontunes&src=typed_query)
+&nbsp; | `until:yyyy-mm-dd` | Before (NOT inclusive) a specified date. Combine with the "since" operator for dates between. | [🔗](https://twitter.com/search?q=since%3A2019-06-12%20until%3A2019-06-28%20%23nasamoontunes&src=typed_query)
+&nbsp; | `max_id:tweet_id` | At or before (inclusive) a specified Snowflake ID (see [Note](#snowflake-ids) below) | [🔗](https://twitter.com/search?q=since_id%3A1138872932887924737%20max_id%3A1144730280353247233%20%23nasamoontunes&src=typed_query)
+&nbsp; | `since_id:tweet_id` | After (NOT inclusive) a specified Snowflake ID | [🔗](https://twitter.com/search?q=since_id%3A1138872932887924737%20max_id%3A1144730280353247233%20%23nasamoontunes&src=typed_query)
 &nbsp; | | | 
 Tweet Type | `filter:nativeretweets` | Only retweets created using the retweet button. Works well combined with `from:` to show only retweets. | [🔗](https://twitter.com/search?q=from%3Anasa%20filter%3Anativeretweets&src=typed_query)
 &nbsp; | `include:nativeretweets` | Native retweets are excluded by default. This shows them. In contrast to `filter:`, which shows only retweets, this includes retweets in addition to other tweets | [🔗](https://twitter.com/search?q=from%3Anasa%20include%3Anativeretweets%20&src=typed_query)


### PR DESCRIPTION
`since` is inclusive, `until` is not.
`since_id` is not inclusive, `max_id` is. 
(I know, it's confusing.)

Also, the old description isn't very explicit about the usage of since_id/max_id respectively, I revised it to clarify as well.